### PR TITLE
Update to Ubuntu Touch 20.04 focal

### DIFF
--- a/app/qml/components/ExpandableListItem.qml
+++ b/app/qml/components/ExpandableListItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 ListItem {
     id: expandableListItem
@@ -45,7 +45,7 @@ ListItem {
                     rotation: expandableListItem.expansion.expanded ? 180 : 0
 
                     Behavior on rotation {
-                        UbuntuNumberAnimation {}
+                        LomiriNumberAnimation {}
                     }
                 }
             }

--- a/app/qml/components/InfoBar.qml
+++ b/app/qml/components/InfoBar.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Rectangle {
     id: infoBar
@@ -49,14 +49,14 @@ Rectangle {
     SequentialAnimation {
         id: animaDestroy
 
-        UbuntuNumberAnimation {
+        LomiriNumberAnimation {
             target: infoBar.anchors
             property: "bottomMargin"
             to: -infoBar.height
             duration: 500; easing.type: Easing.InOutCirc
         }
 
-        UbuntuNumberAnimation {
+        LomiriNumberAnimation {
             target: infoBar
             property: "opacity"
             to: 0
@@ -66,10 +66,10 @@ Rectangle {
 
 
     Behavior on opacity {
-        UbuntuNumberAnimation { duration: 500; easing.type: Easing.InOutCirc }
+        LomiriNumberAnimation { duration: 500; easing.type: Easing.InOutCirc }
     }
 
     Behavior on anchors.bottomMargin {
-        UbuntuNumberAnimation { duration: 500; easing.type: Easing.InOutCirc }
+        LomiriNumberAnimation { duration: 500; easing.type: Easing.InOutCirc }
     }
 }

--- a/app/qml/components/NotificationServiceItem.qml
+++ b/app/qml/components/NotificationServiceItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import "../components"
 
 Item {

--- a/app/qml/components/StandardListItem.qml
+++ b/app/qml/components/StandardListItem.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.4
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 ListItem {
     id: listItem

--- a/app/qml/pages/ExportPage.qml
+++ b/app/qml/pages/ExportPage.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.9
-import Ubuntu.Components 1.3
-import Ubuntu.Content 1.3
+import Lomiri.Components 1.3
+import Lomiri.Content 1.3
 import "../components"
 
 Page {

--- a/app/qml/pages/InfoPage.qml
+++ b/app/qml/pages/InfoPage.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Page {
 
@@ -33,7 +33,7 @@ Page {
         anchors.top: header.bottom
         width:parent.width
 
-        UbuntuShape {
+        LomiriShape {
             width: units.gu(15); height: units.gu(15)
             anchors.horizontalCenter: parent.horizontalCenter
             radius: "medium"
@@ -53,7 +53,7 @@ Page {
 
         Label {
             width: parent.width
-            color: UbuntuColors.ash
+            color: LomiriColors.ash
             horizontalAlignment: Text.AlignHCenter
             text: i18n.tr("Version ") + "0.0.7"
         }
@@ -67,7 +67,7 @@ Page {
 
         Label {
             width: parent.width
-            linkColor: UbuntuColors.orange
+            linkColor: LomiriColors.orange
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             //TRANSLATORS: Please make sure the URLs are correct

--- a/app/qml/pages/LoadingPage.qml
+++ b/app/qml/pages/LoadingPage.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Page {
     id: root

--- a/app/qml/pages/LocationPicker.qml
+++ b/app/qml/pages/LocationPicker.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Page {
 

--- a/app/qml/pages/MainMenuPage.qml
+++ b/app/qml/pages/MainMenuPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.4
 import QtQuick.Controls.Suru 2.2
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import "../components"
 
 Page {

--- a/app/qml/pages/ScreenshotPage.qml
+++ b/app/qml/pages/ScreenshotPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Content 1.3
+import Lomiri.Components 1.3
+import Lomiri.Content 1.3
 
 Page {
     id: scrShot

--- a/app/qml/pages/WatchesPage.qml
+++ b/app/qml/pages/WatchesPage.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.4
 import QtQuick.Controls.Suru 2.2
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Page {
     id: watchesPage

--- a/app/qml/pages/WeatherSettingsDialog.qml
+++ b/app/qml/pages/WeatherSettingsDialog.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 
 Page {
 

--- a/app/qml/telescope.qml
+++ b/app/qml/telescope.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.4
 import QtQuick.Controls.Suru 2.2
-import Ubuntu.Components 1.3
+import Lomiri.Components 1.3
 import org.asteroid.syncservice 1.0
 import "controller"
 

--- a/asteroidsyncserviced.apparmor
+++ b/asteroidsyncserviced.apparmor
@@ -8,5 +8,5 @@
         "content_exchange_source"
     ],
     "template": "unconfined",
-    "policy_version": 16.04
+    "policy_version": 20.04
 }

--- a/clickable.yaml
+++ b/clickable.yaml
@@ -1,4 +1,4 @@
-clickable_minimum_required: 7.1.2
+clickable_minimum_required: 8.0.0
 builder: qmake
 kill: telescope
 build_args: CONFIG+=telescope

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -15,6 +15,6 @@
     },
     "version": "0.0.7",
     "maintainer": "Stefan Weng <stefwe@mailbox.org>",
-    "framework" : "ubuntu-sdk-16.04.5"
+    "framework" : "ubuntu-sdk-20.04"
 }
 

--- a/telescope.apparmor
+++ b/telescope.apparmor
@@ -5,5 +5,5 @@
         "accounts"
     ],
     "template": "unconfined",
-    "policy_version": 16.04
+    "policy_version": 20.04
 }

--- a/telescope.desktop.in
+++ b/telescope.desktop.in
@@ -4,4 +4,4 @@ Exec=env QML2_IMPORT_PATH=usr/lib/$${ARCH_TRIPLET}/qt5/qml telescope
 Icon=assets/icon.svg
 Terminal=false
 Type=Application
-X-Ubuntu-Touch=true
+X-Lomiri-Touch=true


### PR DESCRIPTION
I have made changes according to https://docs.ubports.com/es/latest/appdev/guides/port-to-focal.html and telescope seems to be working.

Closes: #63

the git submodule should be updated according to that pull request.
https://github.com/AsteroidOS/asteroidsyncservice/pull/58